### PR TITLE
Fix to validate if the header and footer files exist before load them

### DIFF
--- a/nbgrader/preprocessors/headerfooter.py
+++ b/nbgrader/preprocessors/headerfooter.py
@@ -9,7 +9,10 @@ from . import NbGraderPreprocessor
 from ..nbgraderformat import read as read_nb
 from nbconvert.exporters.exporter import ResourcesDict
 from nbformat.notebooknode import NotebookNode
+
+from pathlib import Path
 from typing import Tuple
+
 
 
 class IncludeHeaderFooter(NbGraderPreprocessor):
@@ -26,7 +29,7 @@ class IncludeHeaderFooter(NbGraderPreprocessor):
         new_cells = []
 
         # header
-        if self.header:
+        if self.header and Path(self.header).exists():
             with io.open(self.header, encoding='utf-8') as fh:
                 header_nb = read_nb(fh, as_version=current_nbformat)
             new_cells.extend(header_nb.cells)
@@ -35,7 +38,7 @@ class IncludeHeaderFooter(NbGraderPreprocessor):
         new_cells.extend(nb.cells)
 
         # footer
-        if self.footer:
+        if self.footer and Path(self.footer).exists():
             with io.open(self.footer, encoding='utf-8') as fh:
                 footer_nb = read_nb(fh, as_version=current_nbformat)
             new_cells.extend(footer_nb.cells)

--- a/nbgrader/tests/preprocessors/test_headerfooter.py
+++ b/nbgrader/tests/preprocessors/test_headerfooter.py
@@ -26,6 +26,22 @@ class TestIncludeHeaderFooter(BaseTestPreprocessor):
         orig_cells = orig_nb.cells[:]
         nb = preprocessor.preprocess(orig_nb, {})[0]
         assert nb.cells == (cells + orig_cells)
+    
+    def test_validate_if_header_exists(self, preprocessor):
+        """Does the prepocess check if the header file exists before load it?"""
+        preprocessor.header = os.path.join(os.path.dirname(__file__), "files", "nonexistent_header.ipynb")
+        
+        orig_nb = self._read_nb(os.path.join("files", "test.ipynb"))
+        nb = preprocessor.preprocess(orig_nb, {})[0]
+        assert nb.cells == orig_nb.cells[:]
+
+    def test_validate_if_footer_exists(self, preprocessor):
+        """Does the prepocess check if the footer file exists before load it?"""
+        preprocessor.footer = os.path.join(os.path.dirname(__file__), "files", "nonexistent_footer.ipynb")
+        
+        orig_nb = self._read_nb(os.path.join("files", "test.ipynb"))
+        nb = preprocessor.preprocess(orig_nb, {})[0]
+        assert nb.cells == orig_nb.cells[:]
 
     def test_concatenate_footer(self, preprocessor):
         """Is the footer appended correctly?"""


### PR DESCRIPTION
If **nbgrader_config.py** is using `c.IncludeHeaderFooter.header` or `c.IncludeHeaderFooter.footer` the code in nbgrader preprocessors do not check if these files exist and it's throwing with 500 error